### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.3](https://github.com/ajac-zero/orpheus/compare/v0.1.2...v0.1.3) - 2025-09-18
+
+### Added
+
+- add hyper backend ([#3](https://github.com/ajac-zero/orpheus/pull/3))
+
+### Fixed
+
+- fix doctests
+
+### Other
+
+- Update rust.yml
+- clean up dependencies
+- refactor tests
+- improve docstrings
+- improve crate visibility
+- clean up prelude
+- init release-plz
+- Update rust.yml
+- Create rust.yml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "orpheus"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orpheus"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "A blazing fast OpenRouter SDK"
 homepage = "https://orpheus.ajac-zero.com"


### PR DESCRIPTION



## 🤖 New release

* `orpheus`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/ajac-zero/orpheus/compare/v0.1.2...v0.1.3) - 2025-09-18

### Added

- add hyper backend ([#3](https://github.com/ajac-zero/orpheus/pull/3))

### Fixed

- fix doctests

### Other

- Update rust.yml
- clean up dependencies
- refactor tests
- improve docstrings
- improve crate visibility
- clean up prelude
- init release-plz
- Update rust.yml
- Create rust.yml
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).