### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/ajac-zero/orpheus/compare/v0.1.3...v0.1.4) - 2025-09-18
+
+### Other
+
+- No subject
+
 ## [0.1.3](https://github.com/ajac-zero/orpheus/compare/v0.1.2...v0.1.3) - 2025-09-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "orpheus"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orpheus"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "A blazing fast OpenRouter SDK"
 homepage = "https://orpheus.ajac-zero.com"


### PR DESCRIPTION



## 🤖 New release

* `orpheus`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/ajac-zero/orpheus/compare/v0.1.3...v0.1.4) - 2025-09-18

### Other

- No subject
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).